### PR TITLE
remove eslint/js styleguide paragraph

### DIFF
--- a/book/frontend/javascript/2.code_conventions_and_linting.md
+++ b/book/frontend/javascript/2.code_conventions_and_linting.md
@@ -20,7 +20,3 @@ for (let i = 0; i < 10; i++) // our config makes eslint complain here!
 ```
 
 If you think the [airbnb styleguide](https://github.com/airbnb/javascript) is too nazi, think again. Come back after having tried [our own](https://github.com/buildo/eslint-config).
-
-## Style Guide
-
-In addition, we also have a WIP [styleguide book](https://buildo.gitbooks.io/js-style-guide/content/guide/01.Types.html), in the same spirit of the `airbnb` one. This should serve as an explanation of the "whys" behind the rules in our eslint config, plus adding more shared code conventions in a descriptive form.


### PR DESCRIPTION
as reported by Miguel, the link is currently a 404 https://buildo.gitbooks.io/js-style-guide